### PR TITLE
Fix deprecation warning

### DIFF
--- a/IProgress/progressbar.py
+++ b/IProgress/progressbar.py
@@ -65,9 +65,9 @@ else:
         simplefilter("ignore")
         try:
             from IPython.html.widgets import IntProgress, TextWidget, \
-                HBox, Latex
+                HBox, Label
         except ImportError:
-            from ipywidgets import IntProgress, Text, HBox, Latex
+            from ipywidgets import IntProgress, Text, HBox, Label
 
     def backend_print(fd, str):
         None
@@ -178,7 +178,7 @@ class ProgressBar(object):
                 if isinstance(widget_type, pbar_widgets.WidgetHFill):
                     children.append(self.bar_widget)
                 else:
-                    text_widget = Latex()
+                    text_widget = Label()
                     children.append(text_widget)
             self.container_widget.children = children
 


### PR DESCRIPTION
Hi @aebrahim,

I was getting a deprecation warning from the Latex widget. It says to use the Label instead.

line 52:
<code>class Latex(Label): 

```
def __init__(self, *args, **kwargs):
    warn('The Latex widget is deprecated. Use Label instead')
    super(Latex, self).__init__(*args, **kwargs)
```

</code>

Cheers,

Joao
